### PR TITLE
Disable GitHub summary when there's only one tox environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,6 @@ lint.select = [
   "ALL",
 ]
 lint.ignore = [
-  "ANN101", # Missing type annotation for `self` in method
   "COM812", # Conflict with formatter
   "CPY",    # No copyright statements
   "D203",   # `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible
@@ -86,6 +85,7 @@ lint.ignore = [
   "D401",   # First line of docstring should be in imperative mood
   "DOC",    # not supported
   "ISC001", # Conflict with formatter
+  "LOG015", # call on root logger
   "S104",   # Possible binding to all interface
 ]
 lint.per-file-ignores."tests/**/*.py" = [

--- a/src/tox_gh/plugin.py
+++ b/src/tox_gh/plugin.py
@@ -70,7 +70,7 @@ def tox_add_core_config(core_conf: ConfigSet, state: State) -> None:
     :param core_conf: the core configuration
     :param state: tox state object
     """
-    global WILL_RUN_MULTIPLE_ENVS
+    global WILL_RUN_MULTIPLE_ENVS  # noqa: PLW0603
 
     core_conf.add_constant(keys="is_on_gh_action", desc="flag for running on Github", value=is_running_on_actions())
 


### PR DESCRIPTION
Resolves #68 by not writing to the summary file if there is only a single tox environment that would be ran for the given Python target.