### PR TITLE
Add conda-forge package badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # tox-gh
 
 [![PyPI version](https://badge.fury.io/py/tox-gh.svg)](https://badge.fury.io/py/tox-gh)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/tox-gh.svg)](https://anaconda.org/conda-forge/tox-gh)
 [![PyPI Supported Python Versions](https://img.shields.io/pypi/pyversions/tox-gh.svg)](https://pypi.python.org/pypi/tox-gh/)
 [![check](https://github.com/tox-dev/tox-gh/actions/workflows/check.yaml/badge.svg)](https://github.com/tox-dev/tox-gh/actions/workflows/check.yaml)
 [![Downloads](https://static.pepy.tech/badge/tox-gh/month)](https://pepy.tech/project/tox-gh)


### PR DESCRIPTION
## Changes

- Adds a badge for the conda-forge package

## Additional information

The badge currently states the last stable version. There is typically a lag of one or two days before the latest stable version is available.