### PR TITLE
✨ feat(plugin): detect freethreaded Python and persist version key

### DIFF
--- a/src/tox_gh/plugin.py
+++ b/src/tox_gh/plugin.py
@@ -45,7 +45,8 @@ def get_python_version_keys() -> list[str]:
         return [f"pypy-{major_minor_version}", f"pypy-{major_version}", f"pypy{major_version}"]
     if hasattr(sys, "pyston_version_info"):  # Pyston
         return [f"piston-{major_minor_version}", f"pyston-{major_version}"]
-    # Assume this is running on CPython
+    if getattr(info, "free_threaded", False):
+        return [f"{major_minor_version}t", major_minor_version, major_version]
     return [major_minor_version, major_version]
 
 
@@ -87,11 +88,15 @@ def tox_add_core_config(core_conf: ConfigSet, state: State) -> None:
     gh_config = state.conf.get_section_config(Section(None, "gh"), base=[], of_type=GhActionsConfigSet, for_env=None)
     python_mapping: dict[str, EnvList] = gh_config["python"]
 
-    env_list = next((python_mapping[i] for i in get_python_version_keys() if i in python_mapping), None)
+    python_version_keys = get_python_version_keys()
+    env_list = next((python_mapping[i] for i in python_version_keys if i in python_mapping), None)
     if env_list is not None:  # override the env_list core configuration with our values
         logging.warning("tox-gh set %s", ", ".join(env_list))
         state.conf.core.loaders.insert(0, MemoryLoader(env_list=env_list))
         WILL_RUN_MULTIPLE_ENVS = len(env_list.envs) > 1
+        if not os.environ.get("TOX_GH_MAJOR_MINOR"):
+            matched_key = next(i for i in python_version_keys if i in python_mapping)
+            os.environ["TOX_GH_MAJOR_MINOR"] = matched_key
 
 
 _STATE = threading.local()

--- a/tests/test_tox_gh.py
+++ b/tests/test_tox_gh.py
@@ -1,22 +1,27 @@
 from __future__ import annotations
 
+import os
 import sys
 from typing import TYPE_CHECKING
-from unittest.mock import ANY
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
 from tox_gh import plugin
+from tox_gh.plugin import get_python_version_keys
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
     from tox.pytest import MonkeyPatch, ToxProjectCreator
 
 
 @pytest.fixture(autouse=True)
-def _clear_env_var(monkeypatch: MonkeyPatch) -> None:
-    monkeypatch.delenv("TOX_GH_MAJOR_MINOR", raising=False)
+def _clear_env_var() -> Iterator[None]:
+    os.environ.pop("TOX_GH_MAJOR_MINOR", None)
+    yield
+    os.environ.pop("TOX_GH_MAJOR_MINOR", None)
 
 
 @pytest.fixture
@@ -187,6 +192,48 @@ def test_gh_single_env_ok(monkeypatch: MonkeyPatch, tox_project: ToxProjectCreat
 
     summary_text = summary_output_path.read_text(encoding="utf-8")
     assert len(summary_text) == 0
+
+
+def test_freethreaded_python_detection(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.delenv("TOX_GH_MAJOR_MINOR", raising=False)
+    mock_info = MagicMock()
+    mock_info.version_info = (3, 13, 1, "final", 0)
+    mock_info.implementation = "CPython"
+    mock_info.free_threaded = True
+    with patch.object(plugin, "PythonInfo") as mock_cls:
+        mock_cls.from_exe.return_value = mock_info
+        result = get_python_version_keys()
+    assert result == ["3.13t", "3.13", "3"]
+
+
+def test_non_freethreaded_python_detection(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.delenv("TOX_GH_MAJOR_MINOR", raising=False)
+    mock_info = MagicMock()
+    mock_info.version_info = (3, 13, 1, "final", 0)
+    mock_info.implementation = "CPython"
+    mock_info.free_threaded = False
+    with patch.object(plugin, "PythonInfo") as mock_cls:
+        mock_cls.from_exe.return_value = mock_info
+        result = get_python_version_keys()
+    assert result == ["3.13", "3"]
+
+
+def test_override_sets_tox_gh_major_minor(monkeypatch: MonkeyPatch, tox_project: ToxProjectCreator) -> None:
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.delenv("TOXENV", raising=False)
+    monkeypatch.delenv("TOX_GH_MAJOR_MINOR", raising=False)
+    ini = f"""
+    [testenv]
+    package = skip
+    [gh]
+    python =
+        {sys.version_info[0]}.{sys.version_info[1]} = a
+    """
+    project = tox_project({"tox.ini": ini})
+    result = project.run()
+    result.assert_success()
+    assert "tox-gh set a" in result.out
+    assert os.environ.get("TOX_GH_MAJOR_MINOR") == f"{sys.version_info[0]}.{sys.version_info[1]}"
 
 
 def test_gh_single_env_fail(


### PR DESCRIPTION
Freethreaded CPython builds (`3.13t`, `3.14t`) were not auto-detected by tox-gh, forcing users to manually set `TOX_GH_MAJOR_MINOR=3.13t` as a workaround. With freethreaded Python gaining adoption across the ecosystem, native support removes this friction. Closes #201.

The plugin now checks `PythonInfo.free_threaded` (available in recent virtualenv) and generates version keys `["3.13t", "3.13", "3"]` for freethreaded builds. This gives priority to a `3.13t` mapping when configured, while falling back to the standard `3.13` mapping if no freethreaded-specific entry exists.

Separately, when tox provisions itself (via a `requires` section), the `MemoryLoader` env_list override was lost across process boundaries because it only existed in memory. The provisioned subprocess would then run all environments instead of the matched subset. Closes #151. 🔧 The fix propagates the resolved version key into `TOX_GH_MAJOR_MINOR` when it wasn't explicitly set, so the provisioned subprocess resolves the same mapping. This only applies when the env var was not already set by the user.