### PR TITLE
✨ feat(plugin): detect freethreaded Python variants

### DIFF
--- a/src/tox_gh/plugin.py
+++ b/src/tox_gh/plugin.py
@@ -45,7 +45,8 @@ def get_python_version_keys() -> list[str]:
         return [f"pypy-{major_minor_version}", f"pypy-{major_version}", f"pypy{major_version}"]
     if hasattr(sys, "pyston_version_info"):  # Pyston
         return [f"piston-{major_minor_version}", f"pyston-{major_version}"]
-    # Assume this is running on CPython
+    if getattr(info, "free_threaded", False):
+        return [f"{major_minor_version}t", major_minor_version, major_version]
     return [major_minor_version, major_version]
 
 

--- a/tests/test_tox_gh.py
+++ b/tests/test_tox_gh.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import sys
 from typing import TYPE_CHECKING
-from unittest.mock import ANY
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
 from tox_gh import plugin
+from tox_gh.plugin import get_python_version_keys
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -187,6 +188,25 @@ def test_gh_single_env_ok(monkeypatch: MonkeyPatch, tox_project: ToxProjectCreat
 
     summary_text = summary_output_path.read_text(encoding="utf-8")
     assert len(summary_text) == 0
+
+
+@pytest.mark.parametrize(
+    ("free_threaded", "expected"),
+    [
+        pytest.param(True, ["3.13t", "3.13", "3"], id="freethreaded"),
+        pytest.param(False, ["3.13", "3"], id="standard"),
+    ],
+)
+def test_freethreaded_python_detection(monkeypatch: MonkeyPatch, free_threaded: bool, expected: list[str]) -> None:
+    monkeypatch.delenv("TOX_GH_MAJOR_MINOR", raising=False)
+    mock_info = MagicMock()
+    mock_info.version_info = (3, 13, 1, "final", 0)
+    mock_info.implementation = "CPython"
+    mock_info.free_threaded = free_threaded
+    with patch.object(plugin, "PythonInfo") as mock_cls:
+        mock_cls.from_exe.return_value = mock_info
+        result = get_python_version_keys()
+    assert result == expected
 
 
 def test_gh_single_env_fail(


### PR DESCRIPTION
Freethreaded CPython builds (`3.13t`, `3.14t`) were not auto-detected by tox-gh, forcing users to manually set `TOX_GH_MAJOR_MINOR=3.13t` as a workaround. With freethreaded Python gaining adoption across the ecosystem, native support removes this friction.

The plugin now checks `PythonInfo.free_threaded` (available in recent virtualenv) and generates version keys `["3.13t", "3.13", "3"]` for freethreaded builds. This gives priority to a `3.13t` mapping when configured, while falling back to the standard `3.13` mapping if no freethreaded-specific entry exists. The `TOX_GH_MAJOR_MINOR` env var workaround continues to work as before.

Closes #201