### PR TITLE
📝 docs(readme): restructure following Diataxis framework

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -7,11 +7,9 @@ on:
   pull_request:
   schedule:
     - cron: "0 8 * * *"
-
 concurrency:
   group: check-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   test:
     name: test with ${{ matrix.env }} on ${{ matrix.os }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,10 +2,8 @@ name: Release to PyPI
 on:
   push:
     tags: ["*"]
-
 env:
   dists-artifact-name: python-package-distributions
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +24,6 @@ jobs:
         with:
           name: ${{ env.dists-artifact-name }}
           path: dist/*
-
   release:
     needs:
       - build

--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -1,0 +1,2 @@
+wrap = 120
+number = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,11 +24,18 @@ repos:
       - id: ruff-format
       - id: ruff-check
         args: ["--fix", "--unsafe-fixes", "--exit-non-zero-on-fix"]
-  - repo: https://github.com/rbubley/mirrors-prettier
-    rev: "v3.8.1"
+  - repo: https://github.com/hukkin/mdformat
+    rev: "1.0.0"
     hooks:
-      - id: prettier
-        args: ["--print-width=120", "--prose-wrap=always"]
+      - id: mdformat
+        additional_dependencies:
+          - mdformat-config>=0.2.1
+          - mdformat-gfm>=1
+          - mdformat-toc>=0.5
+  - repo: https://github.com/google/yamlfmt
+    rev: "v0.21.0"
+    hooks:
+      - id: yamlfmt
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/README.md
+++ b/README.md
@@ -5,168 +5,360 @@
 [![check](https://github.com/tox-dev/tox-gh/actions/workflows/check.yaml/badge.svg)](https://github.com/tox-dev/tox-gh/actions/workflows/check.yaml)
 [![Downloads](https://static.pepy.tech/badge/tox-gh/month)](https://pepy.tech/project/tox-gh)
 
-**tox-gh** is a tox plugin, which helps run tox on GitHub Actions with multiple different Python versions on multiple
-workers in parallel.
+Seamless integration of tox into GitHub Actions.
 
-## Features
+**tox-gh** automatically selects which tox environments to run on each Python version in your GitHub Actions matrix,
+allowing parallel test execution across multiple workers.
 
-When running tox on GitHub Actions, tox-gh:
+<!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 
-- detects which environment to run based on configurations (or bypasses detection and sets it explicitly via the
-  `TOX_GH_MAJOR_MINOR` environment variable),
-- provides utilities such as
-  [grouping log lines](https://github.com/actions/toolkit/blob/main/docs/commands.md#group-and-ungroup-log-lines).
+- [Tutorial: Getting Started](#tutorial-getting-started)
+  - [Prerequisites](#prerequisites)
+  - [Step 1: Add tox-gh configuration](#step-1-add-tox-gh-configuration)
+  - [Step 2: Create a GitHub Actions workflow](#step-2-create-a-github-actions-workflow)
+  - [Step 3: Push and verify](#step-3-push-and-verify)
+- [How-to Guides](#how-to-guides)
+  - [How to run multiple environments on a single Python version](#how-to-run-multiple-environments-on-a-single-python-version)
+  - [How to test freethreaded Python builds](#how-to-test-freethreaded-python-builds)
+  - [How to explicitly set the Python version](#how-to-explicitly-set-the-python-version)
+  - [How to bypass tox-gh environment selection](#how-to-bypass-tox-gh-environment-selection)
+  - [How to use with uv](#how-to-use-with-uv)
+- [Reference](#reference)
+  - [Configuration](#configuration)
+    - [`[gh.python]`](#ghpython)
+  - [Environment Variables](#environment-variables)
+    - [`GITHUB_ACTIONS`](#github_actions)
+    - [`TOX_GH_MAJOR_MINOR`](#tox_gh_major_minor)
+    - [`TOXENV`](#toxenv)
+  - [Python Version Detection](#python-version-detection)
+  - [GitHub Actions Integration](#github-actions-integration)
+    - [Log Grouping](#log-grouping)
+    - [Step Summary](#step-summary)
+  - [Behavior](#behavior)
+    - [Activation Conditions](#activation-conditions)
+    - [Environment Selection](#environment-selection)
+    - [Subprocess Provisioning](#subprocess-provisioning)
+- [Explanation](#explanation)
+  - [Why tox-gh exists](#why-tox-gh-exists)
+  - [How environment selection works](#how-environment-selection-works)
+  - [Design decisions](#design-decisions)
+  - [Comparison to tox-gh-actions](#comparison-to-tox-gh-actions)
+  - [Limitations](#limitations)
 
-## Usage
+<!-- mdformat-toc end -->
 
-1. Add configurations under `[gh]` section along with your tox configuration.
-2. Install `tox-gh` package in the GitHub Actions workflow before running `tox` command.
+______________________________________________________________________
 
-## Examples
+## Tutorial: Getting Started
 
-### Basic Example
+This guide walks you through setting up tox-gh for the first time.
 
-Add `[gh]` section to the same file as tox configuration.
+### Prerequisites
 
-If you're using `tox.ini`:
+You'll need a Python project already using tox 4 with a `tox.toml`, `tox.ini`, or `pyproject.toml` configuration file.
 
-```ini
-[gh]
-python =
-    3.14t = 3.14t
-    3.14 = 3.14, type, dev, pkg_meta
-    3.13 = 3.13
-    3.12 = 3.12
-```
+### Step 1: Add tox-gh configuration
+
+Open your tox configuration file and add a `[gh]` section that maps Python versions to tox environments.
 
 For `tox.toml`:
 
 ```toml
 [gh.python]
-"3.14t" = ["3.14t"]
-"3.14" = ["3.14", "type", "pkg_meta"]
-"3.13" = ["3.13"]
-"3.12" = ["3.12"]
+"3.13" = ["py313"]
+"3.12" = ["py312"]
 ```
 
-For `pyproject.toml`:
+This tells tox-gh: "When running on Python 3.13, run the `py313` environment. When running on Python 3.12, run the
+`py312` environment."
+
+### Step 2: Create a GitHub Actions workflow
+
+Create `.github/workflows/test.yaml`:
+
+```yaml
+name: test
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.13', '3.12']
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Install tox
+        run: |
+          uv tool install --python ${{ matrix.python-version }} tox --with tox-gh
+      - name: Run tests
+        run: tox
+```
+
+### Step 3: Push and verify
+
+Commit your changes and push to GitHub. The workflow will run automatically. You'll see:
+
+- Two parallel jobs (one for Python 3.13, one for 3.12)
+- Each job runs only its corresponding tox environment
+- GitHub Actions log groups organize output by environment
+
+You've successfully integrated tox-gh. The plugin now handles environment selection automatically based on which Python
+version GitHub Actions provides.
+
+______________________________________________________________________
+
+## How-to Guides
+
+### How to run multiple environments on a single Python version
+
+Add a list of environments for a Python version:
 
 ```toml
-[tool.tox.gh.python]
-"3.14t" = ["3.14t"]
-"3.14" = ["3.14", "type", "pkg_meta"]
-"3.13" = ["3.13"]
-"3.12" = ["3.12"]
+[gh.python]
+"3.13" = ["py313", "type", "lint"]
 ```
 
-This will run a different set of tox environments on different Python versions set up via GitHub `setup-python` action:
+Now the Python 3.13 job will run three tox environments sequentially: `py313`, `type`, and `lint`.
 
-- on Python 3.14t job, tox runs `3.14t` environment,
-- on Python 3.14 job, tox runs `3.14`, `type` and `pkg_meta` environments,
-- on Python 3.13 job, tox runs `3.13` environment,
-- on Python 3.12 job, tox runs `3.12` environment,
+### How to test freethreaded Python builds
 
-#### Workflow Configuration
+Freethreaded Python (3.13t, 3.14t) is automatically detected. Map it like any other version:
 
-A bare-bones example would be `.github/workflows/check.yaml`:
+```toml
+[gh.python]
+"3.14t" = ["py314t"]
+"3.14" = ["py314", "type"]
+```
+
+The plugin checks for the freethreaded attribute and generates the correct version key with the `t` suffix.
+
+### How to explicitly set the Python version
+
+If automatic detection doesn't work for your setup, set `TOX_GH_MAJOR_MINOR`:
 
 ```yaml
-jobs:
-  test:
-    name: test with ${{ matrix.env }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        env:
-          - "3.14t"
-          - "3.14"
-          - "3.13"
-        os:
-          - ubuntu-latest
-          - macos-latest
-    steps:
-      - uses: actions/checkout@v5
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v7
-      - name: Install tox
-        run: uv tool install --python-preference only-managed --python 3.14 tox --with tox-uv --with tox-gh
-      - name: Install Python
-        if: matrix.env != '3.14'
-        run: uv python install --python-preference only-managed ${{ matrix.env }}
-      - name: Setup test suite
-        run: tox run -vv --notest --skip-missing-interpreters false
-        env:
-          TOX_GH_MAJOR_MINOR: ${{ matrix.env }}
-      - name: Run test suite
-        run: tox run --skip-pkg-install
-        env:
-          TOX_GH_MAJOR_MINOR: ${{ matrix.env }}
+  - name: Run tests
+    run: tox
+    env:
+      TOX_GH_MAJOR_MINOR: ${{ matrix.python-version }}
 ```
 
-A more exhaustive example would be `.github/workflows/check.yaml`:
+This forces tox-gh to use the matrix value instead of detecting the Python version.
+
+### How to bypass tox-gh environment selection
+
+Run tox with an explicit environment list:
+
+```bash
+tox -e py313,lint
+```
+
+Or set the `TOXENV` environment variable:
 
 ```yaml
-name: check
-on:
-  workflow_dispatch:
-  push:
-    branches: ["main"]
-    tags-ignore: ["**"]
-  pull_request:
-  schedule: # Runs at 8 AM every day
-    - cron: "0 8 * * *"
-
-concurrency:
-  group: check-${{ github.ref }}
-  cancel-in-progress: true
-
-jobs:
-  test:
-    name: test with ${{ matrix.env }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        env:
-          - "3.14t"
-          - "3.14"
-          - "3.13"
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Add .local/bin to Windows PATH
-        if: runner.os == 'Windows'
-        shell: bash
-        run: echo "$USERPROFILE/.local/bin" >> $GITHUB_PATH
-      - name: Install tox
-        run: uv tool install --python-preference only-managed --python 3.14 tox --with tox-uv --with tox-gh
-      - name: Install Python
-        if: matrix.env != '3.14'
-        run: uv python install --python-preference only-managed ${{ matrix.env }}
-      - name: Setup test suite
-        run: tox run -vv --notest --skip-missing-interpreters false
-        env:
-          TOX_GH_MAJOR_MINOR: ${{ matrix.env }}
-      - name: Run test suite
-        run: tox run --skip-pkg-install
-        env:
-          TOX_GH_MAJOR_MINOR: ${{ matrix.env }}
+env:
+  TOXENV: py313,lint
 ```
 
-## FAQ
+When you specify environments explicitly, tox-gh respects your choice and skips its own selection logic.
 
-- When a list of environments to run is specified explicitly via `-e` option or `TOXENV` environment variable `tox-gh`
-  respects the given environments and simply runs the given environments without enforcing its configuration.
-- The plugin only activates if the environment variable `GITHUB_ACTIONS` is `true`.
+### How to use with uv
+
+Install both tox and tox-gh as uv tools:
+
+```yaml
+  - name: Install tox
+    run: uv tool install tox --with tox-uv --with tox-gh
+```
+
+The `--with` flag ensures tox-gh is available when tox runs.
+
+______________________________________________________________________
+
+## Reference
+
+### Configuration
+
+#### `[gh.python]`
+
+Maps Python version strings to lists of tox environments.
+
+**Type**: `dict[str, list[str]]`
+
+**Location**: The configuration can be placed in `tox.ini` under `[gh] python = ...`, in `tox.toml` under `[gh.python]`,
+or in `pyproject.toml` under `[tool.tox.gh.python]`.
+
+**Format**:
+
+```ini
+[gh.python]
+"<version>" = ["<env>", ...]
+```
+
+**Version keys** (in priority order): Freethreaded Python versions use `"3.14t"` or `"3.13t"`. Standard CPython versions
+use `"3.14"`, `"3.13"`, `"3.12"`, `"3.11"`, or `"3.10"`. Major-only fallbacks use `"3"`. PyPy versions use
+`"pypy-3.13"`, `"pypy-3"`, or `"pypy3"`. Pyston versions use `"piston-3.13"` or `"pyston-3"`.
+
+**Examples**:
+
+```toml
+# Run one environment per version
+[gh.python]
+"3.13" = ["py313"]
+
+# Run multiple environments on one version
+[gh.python]
+"3.13" = ["py313", "type", "lint"]
+
+# Freethreaded Python
+[gh.python]
+"3.14t" = ["py314t"]
+"3.14" = ["py314"]
+
+# Fallback to major version
+[gh.python]
+"3" = ["py3"]
+```
+
+### Environment Variables
+
+#### `GITHUB_ACTIONS`
+
+**Required**: Must be `"true"` for the plugin to activate.
+
+Automatically set by GitHub Actions. The plugin does nothing when running locally.
+
+#### `TOX_GH_MAJOR_MINOR`
+
+**Optional**: Override automatic Python version detection.
+
+**Values**: Any string matching a key in `[gh.python]` (e.g., `"3.13"`, `"3.14t"`)
+
+**Use cases**: This variable is useful when using `uv python install` instead of `setup-python`, for freethreaded builds
+that need explicit version specification, or when automatic detection fails.
+
+**Example**:
+
+```yaml
+env:
+  TOX_GH_MAJOR_MINOR: ${{ matrix.python-version }}
+```
+
+#### `TOXENV`
+
+**Optional**: Explicitly specify which tox environments to run.
+
+When set, tox-gh is completely bypassed and tox runs the specified environments.
+
+**Example**:
+
+```yaml
+env:
+  TOXENV: py313,lint
+```
+
+### Python Version Detection
+
+The plugin detects the Python version by first checking the `TOX_GH_MAJOR_MINOR` environment variable (highest
+priority). If not set, it uses `virtualenv.discovery.py_info.PythonInfo.from_exe()` introspection to check the
+`free_threaded` attribute (appending a `t` suffix if true), check the `implementation` (handling PyPy, Pyston, or
+CPython), and extract major and minor version numbers.
+
+The detection returns a prioritized list of version keys to try. For freethreaded CPython 3.13, it returns
+`["3.13t", "3.13", "3"]`. For standard CPython 3.13, it returns `["3.13", "3"]`. For PyPy 3.13, it returns
+`["pypy-3.13", "pypy-3", "pypy3"]`.
+
+The plugin uses the first matching key found in your `[gh.python]` configuration.
+
+### GitHub Actions Integration
+
+#### Log Grouping
+
+The plugin creates collapsible log groups using GitHub Actions commands. The `::group::tox:install` group contains the
+package installation phase. Each environment's test run gets its own `::group::tox:{env-name}` group. The `::endgroup::`
+command closes the current group. This organization makes long CI logs more readable by sectioning output.
+
+#### Step Summary
+
+When running multiple environments (2 or more), the plugin writes to `$GITHUB_STEP_SUMMARY`. Environment passes are
+marked with ✓ `:white_check_mark:: env-name` and failures with ✗ `:negative_squared_cross_mark:: env-name`.
+Single-environment runs don't produce summary output.
+
+### Behavior
+
+#### Activation Conditions
+
+The plugin activates when `GITHUB_ACTIONS=true`, no explicit `-e` flag was passed to tox, and the `TOXENV` environment
+variable is not set. Otherwise it remains inactive.
+
+#### Environment Selection
+
+When active, the plugin first detects the Python version and returns a prioritized key list. It looks up the first
+matching key in the `[gh.python]` mapping, inserts the matching environments into tox's env_list via `MemoryLoader`, and
+sets the `TOX_GH_MAJOR_MINOR` environment variable (if not already set) for subprocess inheritance.
+
+#### Subprocess Provisioning
+
+When tox provisions itself (via `requires` in tox config), the matched version key is propagated to the subprocess via
+`TOX_GH_MAJOR_MINOR`. This ensures provisioned tox processes apply the same environment filtering.
+
+______________________________________________________________________
+
+## Explanation
+
+### Why tox-gh exists
+
+GitHub Actions workflows typically define a matrix strategy with multiple Python versions:
+
+```yaml
+strategy:
+  matrix:
+    python-version: ['3.13', '3.12', '3.11']
+```
+
+Each matrix cell spawns a separate worker. Without tox-gh, you can either run all tox environments on every worker
+(which is wasteful and redundant) or manually specify which environments to run via `TOXENV` (which is verbose and
+error-prone). tox-gh eliminates both problems by automatically mapping Python versions to appropriate tox environments
+based on simple configuration.
+
+### How environment selection works
+
+The plugin hooks into tox's configuration system via `tox_add_core_config`. When tox starts, it checks if running in
+GitHub Actions (`GITHUB_ACTIONS=true`), verifies the user hasn't specified explicit environments (respecting `-e` and
+`TOXENV`), detects the current Python version via `virtualenv`'s introspection, matches the version against the
+`[gh.python]` mapping, and overrides tox's env_list with the matched environments. This happens before tox creates any
+environments, so tox never sees the unfiltered list.
+
+### Design decisions
+
+**Why not use tox factors?**
+
+Tox 4's native platform factors (`linux`, `darwin`, `win32`) work well for OS-based selection. However, Python version
+factors still require explicitly setting which environments to run. tox-gh provides automatic version-based selection
+without workflow boilerplate.
+
+**Why detect Python version instead of reading workflow matrix?**
+
+The workflow matrix is not accessible from inside the tox process. GitHub Actions only exposes it via environment
+variables you explicitly pass. Auto-detection means zero required environment variables in simple cases.
+
+**Why propagate version key to subprocesses?**
+
+When tox provisions itself (installs dependencies into an isolated environment and re-invokes), the `MemoryLoader`
+override exists only in the parent process. Without propagation, the child tox process would run all environments.
+Setting `TOX_GH_MAJOR_MINOR` in `os.environ` makes it inherit automatically.
+
+### Comparison to tox-gh-actions
+
+tox-gh-actions offers more configuration flexibility (`[gh-actions:env]` for arbitrary matrix variables) but requires
+tox 3 or 4. tox-gh is simpler (Python version mapping only) and requires tox 4+. For most projects, Python version
+mapping is sufficient since tox 4's factor conditions handle other use cases natively.
+
+### Limitations
+
+The plugin only supports Python version-based environment selection and requires tox 4.31 or higher. It does not support
+arbitrary workflow matrix variables beyond Python versions. Version detection may fail with unusual Python
+installations, in which case you should use the `TOX_GH_MAJOR_MINOR` override.


### PR DESCRIPTION
The existing README was structured as a mix of examples and reference material without clear separation between learning resources and technical documentation. This made it harder for new users to get started and for experienced users to find specific information quickly. 📚

The rewrite follows the Diataxis framework with four distinct sections. The Tutorial section provides a step-by-step learning path for first-time users. How-to Guides offer task-oriented solutions for common scenarios like running multiple environments or testing freethreaded Python builds. The Reference section documents all configuration options, environment variables, and behavior as neutral technical descriptions. The Explanation section provides understanding-oriented context about design decisions and how the plugin works internally.

Additionally, bullet-point lists were converted to paragraph prose throughout for better readability. All sentences now end with proper punctuation. The formatting tools were updated to match pytest-env by replacing prettier with mdformat (including gfm, toc, and config plugins) and adding yamlfmt for YAML files.