### PR TITLE
Run ty at max strictness (--error all)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dynamic = [
 ]
 dependencies = [
   "tox>=4.31",
+  "typing-extensions>=4.12; python_version<'3.12'",
 ]
 optional-dependencies.testing = [
   "covdefaults>=2.3",

--- a/src/tox_gh/plugin.py
+++ b/src/tox_gh/plugin.py
@@ -10,6 +10,11 @@ import sys
 import threading
 from typing import TYPE_CHECKING, Any
 
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
 from tox.config.loader.memory import MemoryLoader
 from tox.config.loader.section import Section
 from tox.config.sets import ConfigSet
@@ -55,6 +60,7 @@ def get_python_version_keys() -> list[str]:
 class GhActionsConfigSet(ConfigSet):
     """GitHub Actions config set."""
 
+    @override
     def register_config(self) -> None:
         """Register the configurations."""
         self.add_config(

--- a/tox.toml
+++ b/tox.toml
@@ -56,7 +56,7 @@ commands = [["pre-commit", "run", "--all-files", "--show-diff-on-failure", { rep
 description = "run type check on code base"
 extras = ["testing"]
 deps = ["ty>=0.0.59"]
-commands = [["ty", "check", "--output-format", "concise", "--error-on-warning", "."]]
+commands = [["ty", "check", "--error", "all", "--output-format", "concise", "--error-on-warning", "."]]
 
 [env.pkg_meta]
 description = "check that the long description is valid"


### PR DESCRIPTION
Follow-up to the ty migration (#278): run `ty check` with `--error all` (every rule an error). Max strictness surfaced one finding — `register_config` overrides `ConfigSet.register_config` without `@typing.override` (missing-override-decorator) — fixed by decorating it with `@override` (version-guarded import; adds `typing-extensions` only for python <3.12). Passes clean via `tox run -e type`.