### PR TITLE
📦 build: move the testing extra to a dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,14 @@ dependencies = [
   "tox>=4.31",
   "typing-extensions>=4.12; python_version<'3.12'",
 ]
-optional-dependencies.testing = [
+urls.Documentation = "https://github.com/tox-dev/tox-gh#tox-gh"
+urls.Homepage = "https://github.com/tox-dev/tox-gh"
+urls.Source = "https://github.com/tox-dev/tox-gh"
+urls.Tracker = "https://github.com/tox-dev/tox-gh/issues"
+entry-points.tox.tox-gh = "tox_gh.plugin"
+
+[dependency-groups]
+test = [
   "covdefaults>=2.3",
   "devpi-process>=1.0.2",
   "diff-cover>=9.7.1",
@@ -51,11 +58,6 @@ optional-dependencies.testing = [
   "pytest-cov>=7",
   "pytest-mock>=3.15.1",
 ]
-urls.Documentation = "https://github.com/tox-dev/tox-gh#tox-gh"
-urls.Homepage = "https://github.com/tox-dev/tox-gh"
-urls.Source = "https://github.com/tox-dev/tox-gh"
-urls.Tracker = "https://github.com/tox-dev/tox-gh/issues"
-entry-points.tox.tox-gh = "tox_gh.plugin"
 
 [tool.hatch]
 version.source = "vcs"

--- a/tox.toml
+++ b/tox.toml
@@ -6,7 +6,7 @@ skip_missing_interpreters = true
 description = "run the tests with pytest under {env_name}"
 package = "wheel"
 wheel_build_env = ".pkg"
-extras = ["testing"]
+dependency_groups = ["test"]
 pass_env = ["DIFF_AGAINST", "PYTEST_*", "TOX_GH_MAJOR_MINOR"]
 set_env.COVERAGE_FILE = { replace = "env", name = "COVERAGE_FILE", default = "{work_dir}{/}.coverage.{env_name}" }
 set_env.COVERAGE_FILECOVERAGE_PROCESS_START = "{tox_root}{/}pyproject.toml"
@@ -54,7 +54,7 @@ commands = [["pre-commit", "run", "--all-files", "--show-diff-on-failure", { rep
 
 [env.type]
 description = "run type check on code base"
-extras = ["testing"]
+dependency_groups = ["test"]
 deps = ["ty>=0.0.59"]
 commands = [["ty", "check", "--error", "all", "--output-format", "concise", "--error-on-warning", "."]]
 
@@ -81,7 +81,8 @@ deps = [
   { replace = "ref", of = [ "env", "release", "deps"], extend = true },
   { replace = "ref", of = [ "requires"], extend = true },
 ]
-extras = ["docs", "testing"]
+extras = ["docs"]
+  dependency_groups = ["test"]
 commands = [["uv", "pip", "tree"], ["python", "-c", 'print(r"{env_python}")']]
 
 [gh.python]


### PR DESCRIPTION
The `testing` dependencies were declared as a `[project.optional-dependencies]` extra, so they shipped in the wheel metadata as an installable `tox-gh[testing]` even though nothing outside the repo consumes them. They exist only to run tox-gh's own test suite, which is what PEP 735 dependency groups are for: development-only dependency sets that stay in the source tree and never reach the published metadata. 📦

This moves the set into a `[dependency-groups]` `test` group and repoints the tox environments that used `extras = ["testing"]` at `dependency_groups = ["test"]`. The packages and their version constraints are unchanged.

The published distribution no longer advertises a `testing` extra; local workflows that installed `tox-gh[testing]` should use the `test` dependency group (`--group test`) or the tox environments instead. Runtime dependencies stay untouched.
